### PR TITLE
[FIX] account_invoice_import: fix external_id for Vendor bills action

### DIFF
--- a/account_invoice_import/wizard/account_invoice_import.py
+++ b/account_invoice_import/wizard/account_invoice_import.py
@@ -521,14 +521,8 @@ class AccountInvoiceImport(models.TransientModel):
             raise UserError(_("You must select an Invoice Import Configuration."))
         parsed_inv = self.get_parsed_invoice()
         invoice = self._update_invoice(parsed_inv)
-        action = iaao.for_xml_id("account", "action_invoice_tree2")
-        action.update(
-            {
-                "view_mode": "form,tree,calendar,graph",
-                "views": False,
-                "res_id": invoice.id,
-            }
-        )
+        action = iaao.for_xml_id("account", "action_move_in_invoice_type")
+        action.update({"domain": [('id', '=', invoice.id)]})
         return action
 
     def xpath_to_dict_helper(self, xml_root, xpath_dict, namespaces):


### PR DESCRIPTION
We can't update action like this:
action.update( { "view_mode": "form,tree,calendar,graph", "views": False, "res_id": invoice.id, } )
Throws error: Non-db action dictionaries should provide either multiple view modes or a single view mode and an optional view id.
